### PR TITLE
Using TestClusterBuilder in Unit Test sample

### DIFF
--- a/src/docs/tutorials_and_samples/testing.md
+++ b/src/docs/tutorials_and_samples/testing.md
@@ -27,7 +27,9 @@ namespace Tests
         [Fact]
         public async Task SaysHelloCorrectly()
         {
-            var cluster = new TestCluster();
+            var builder = new TestClusterBuilder();
+            builder.Options.ServiceId = Guid.NewGuid().ToString();
+            var cluster = builder.Build();
             cluster.Deploy();
 
             var hello = cluster.GrainFactory.GetGrain<IHelloGrain>(Guid.NewGuid());


### PR DESCRIPTION
From #6, the sample wasn't compiling because `TestCluster` doesn't have a parameterless constructor. Changing to use the `TestClusterBuilder` so the Unit Test sample builds and runs.