### PR TITLE
Publish docs on Microsoft Docs

### DIFF
--- a/src/docfx.json
+++ b/src/docfx.json
@@ -43,8 +43,7 @@
     ],
     "overwrite": [
       {
-        "files": [
-        ],
+        "files": [],
         "exclude": [
           "obj/**",
           "_site/**"
@@ -53,7 +52,8 @@
     ],
     "dest": "../_site",
     "template": [
-      "default", "template"
+      "default",
+      "template"
     ],
     "noLangKeyword": false,
     "globalMetadata": {
@@ -63,8 +63,9 @@
         "repo": "https://github.com/dotnet/orleans-docs",
         "branch": "master"
       },
-	  "_gitUrlPattern": "github",
-    "_docfxVersion": "2"
+      "_gitUrlPattern": "github",
+      "_docfxVersion": "2",
+      "layout": "page"
     },
     "sitemap": {
       "baseUrl": "https://dotnet.github.io/orleans"

--- a/src/docs/benefits.md
+++ b/src/docs/benefits.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Main Benefits
 ---
 

--- a/src/docs/deployment/azure_web_apps_with_azure_cloud_services.md
+++ b/src/docs/deployment/azure_web_apps_with_azure_cloud_services.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Using Azure Web Apps with Azure Cloud Services
 ---
 

--- a/src/docs/deployment/consul_deployment.md
+++ b/src/docs/deployment/consul_deployment.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Using Consul as a Membership Provider
 ---
 

--- a/src/docs/deployment/docker_deployment.md
+++ b/src/docs/deployment/docker_deployment.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Docker Deployment
 ---
 

--- a/src/docs/deployment/handling_failures.md
+++ b/src/docs/deployment/handling_failures.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Handling Failures
 ---
 

--- a/src/docs/deployment/index.md
+++ b/src/docs/deployment/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Running the Application
 ---
 

--- a/src/docs/deployment/kubernetes.md
+++ b/src/docs/deployment/kubernetes.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Kubernetes hosting
 ---
 

--- a/src/docs/deployment/multi-cluster_support/GlobalSingleInstance.md
+++ b/src/docs/deployment/multi-cluster_support/GlobalSingleInstance.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Global-Single-Instance Grains
 ---
 

--- a/src/docs/deployment/multi-cluster_support/GossipChannels.md
+++ b/src/docs/deployment/multi-cluster_support/GossipChannels.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Multi-Cluster Communication
 ---
 

--- a/src/docs/deployment/multi-cluster_support/MultiClusterConfiguration.md
+++ b/src/docs/deployment/multi-cluster_support/MultiClusterConfiguration.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Multi-Cluster Configuration
 ---
 

--- a/src/docs/deployment/multi-cluster_support/Overview.md
+++ b/src/docs/deployment/multi-cluster_support/Overview.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Multi-Cluster Support
 ---
 

--- a/src/docs/deployment/multi-cluster_support/SiloConfiguration.md
+++ b/src/docs/deployment/multi-cluster_support/SiloConfiguration.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Multi-Cluster Silo Configuration
 ---
 

--- a/src/docs/deployment/service_fabric.md
+++ b/src/docs/deployment/service_fabric.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Service Fabric Hosting
 ---
 # Service Fabric Hosting

--- a/src/docs/deployment/troubleshooting_azure_cloud_services_deployments.md
+++ b/src/docs/deployment/troubleshooting_azure_cloud_services_deployments.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Troubleshooting Deployments
 ---
 

--- a/src/docs/deployment/troubleshooting_deployments.md
+++ b/src/docs/deployment/troubleshooting_deployments.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Troubleshooting Deployments
 ---
 

--- a/src/docs/docfx.json
+++ b/src/docs/docfx.json
@@ -3,10 +3,11 @@
     "content": [
       {
         "files": [
-          "**/*.md",
-          "**/*.yml"
+          "**/**.yml",
+          "**/**.md"
         ],
         "exclude": [
+          "**/_site/**",
           "**/obj/**",
           "**/includes/**",
           "_themes/**",
@@ -23,24 +24,59 @@
     "resource": [
       {
         "files": [
+          "README.md",
+          "Build.cmd",
+          "Test.cmd",
+          "assets/**",
+          "images/**",
           "**/*.png",
-          "**/*.jpg"
+          "**/*.jpg",
+          "**/*.jpeg",
+          "**/*.svg",
+          "**/*.gif",
+          "**/*.ppt",
+          "**/*.pptx",
+          "**/*.pdf",
+          "logo.svg",
+          "logo-light.svg",
+          "tutorials_and_samples/**.png",
+          "blog/media/**.png",
+          "blog/media/**.jpg",
+          "google8df5bb4c968b406e.html"
         ],
         "exclude": [
           "**/obj/**",
-          "**/includes/**",
-          "_themes/**",
-          "_themes.pdf/**",
-          "**/docfx.json",
-          "_repo.en-us/**"
+          "**/_site/**"
         ]
       }
     ],
-    "overwrite": [],
-    "externalReference": [],
-    "globalMetadata": {},
-    "fileMetadata": {},
-    "template": [],
-    "dest": "dotnet-orleans"
+    "overwrite": [
+      {
+        "files": [],
+        "exclude": [
+          "**/obj/**",
+          "**/_site/**"
+        ]
+      }
+    ],
+    "dest": "../_site",
+    "template": [
+      "default",
+      "template"
+    ],
+    "noLangKeyword": false,
+    "globalMetadata": {
+      "_appTitle": "Microsoft Orleans Documentation",
+      "_enableSearch": true,
+      "_gitContribute": {
+        "repo": "https://github.com/dotnet/orleans-docs",
+        "branch": "main"
+      },
+      "_gitUrlPattern": "github",
+      "_docfxVersion": "2"
+    },
+    "sitemap": {
+      "baseUrl": "https://docs.microsoft.com/dotnet/orleans/"
+    }
   }
 }

--- a/src/docs/grains/cancellation_tokens.md
+++ b/src/docs/grains/cancellation_tokens.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Grain cancellation tokens
 ---
 

--- a/src/docs/grains/code_generation.md
+++ b/src/docs/grains/code_generation.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Code Generation
 ---
 

--- a/src/docs/grains/event_sourcing/event_sourcing_configuration.md
+++ b/src/docs/grains/event_sourcing/event_sourcing_configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Configuration
 ---
 

--- a/src/docs/grains/event_sourcing/immediate_vs_delayed_confirmation.md
+++ b/src/docs/grains/event_sourcing/immediate_vs_delayed_confirmation.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Immediate vs. Delayed Confirmation
 ---
 

--- a/src/docs/grains/event_sourcing/index.md
+++ b/src/docs/grains/event_sourcing/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Event Sourcing Overview
 ---
 

--- a/src/docs/grains/event_sourcing/journaledgrain_basics.md
+++ b/src/docs/grains/event_sourcing/journaledgrain_basics.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: JournaledGrain API
 ---
 

--- a/src/docs/grains/event_sourcing/journaledgrain_diagnostics.md
+++ b/src/docs/grains/event_sourcing/journaledgrain_diagnostics.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: JournaledGrain Diagnostics
 ---
 

--- a/src/docs/grains/event_sourcing/log_consistency_providers.md
+++ b/src/docs/grains/event_sourcing/log_consistency_providers.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Log-Consistency Providers
 ---
 

--- a/src/docs/grains/event_sourcing/replicated_instances.md
+++ b/src/docs/grains/event_sourcing/replicated_instances.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Replicated Grains
 ---
 

--- a/src/docs/grains/external_tasks_and_grains.md
+++ b/src/docs/grains/external_tasks_and_grains.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: External Tasks and Grains
 ---
 

--- a/src/docs/grains/grain_identity.md
+++ b/src/docs/grains/grain_identity.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Grain Identity
 ---
 

--- a/src/docs/grains/grain_lifecycle.md
+++ b/src/docs/grains/grain_lifecycle.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Grain Lifecycle
 ---
 

--- a/src/docs/grains/grain_persistence/azure_storage.md
+++ b/src/docs/grains/grain_persistence/azure_storage.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Azure Storage Grain Persistence
 ---
 

--- a/src/docs/grains/grain_persistence/dynamodb_storage.md
+++ b/src/docs/grains/grain_persistence/dynamodb_storage.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Amazon DynamoDB Grain Persistence
 ---
 

--- a/src/docs/grains/grain_persistence/index.md
+++ b/src/docs/grains/grain_persistence/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Persistence
 ---
 

--- a/src/docs/grains/grain_persistence/relational_storage.md
+++ b/src/docs/grains/grain_persistence/relational_storage.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: ADO.NET Grain Persistence
 ---
 

--- a/src/docs/grains/grain_placement.md
+++ b/src/docs/grains/grain_placement.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Grain Placement
 ---
 

--- a/src/docs/grains/grainservices.md
+++ b/src/docs/grains/grainservices.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: GrainServices
 ---
 

--- a/src/docs/grains/index.md
+++ b/src/docs/grains/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Developing a Grain
 ---
 

--- a/src/docs/grains/interceptors.md
+++ b/src/docs/grains/interceptors.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Grain Call Filters
 ---
 

--- a/src/docs/grains/observers.md
+++ b/src/docs/grains/observers.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Observers
 ---
 

--- a/src/docs/grains/reentrancy.md
+++ b/src/docs/grains/reentrancy.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Reentrancy
 ---
 

--- a/src/docs/grains/request_context.md
+++ b/src/docs/grains/request_context.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Request Context
 ---
 

--- a/src/docs/grains/stateless_worker_grains.md
+++ b/src/docs/grains/stateless_worker_grains.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Stateless Worker Grains
 ---
 

--- a/src/docs/grains/timers_and_reminders.md
+++ b/src/docs/grains/timers_and_reminders.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Timers and Reminders
 ---
 

--- a/src/docs/grains/transactions.md
+++ b/src/docs/grains/transactions.md
@@ -1,5 +1,4 @@
 ﻿---
-layout: page
 title: Transactions in Orleans 2.0
 ---
 

--- a/src/docs/host/client.md
+++ b/src/docs/host/client.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Clients
 ---
 

--- a/src/docs/host/configuration_guide/activation_garbage_collection.md
+++ b/src/docs/host/configuration_guide/activation_garbage_collection.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Activation Garbage Collection
 ---
 

--- a/src/docs/host/configuration_guide/client_configuration.md
+++ b/src/docs/host/configuration_guide/client_configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Client Configuration
 ---
 

--- a/src/docs/host/configuration_guide/configuring_.NET_garbage_collection.md
+++ b/src/docs/host/configuration_guide/configuring_.NET_garbage_collection.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Configuring .NET Garbage Collection
 ---
 

--- a/src/docs/host/configuration_guide/configuring_ADO.NET_providers.md
+++ b/src/docs/host/configuration_guide/configuring_ADO.NET_providers.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Configuring ADO.NET Providers
 ---
 

--- a/src/docs/host/configuration_guide/index.md
+++ b/src/docs/host/configuration_guide/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Configuration Guide
 ---
 

--- a/src/docs/host/configuration_guide/list_of_options_classes.md
+++ b/src/docs/host/configuration_guide/list_of_options_classes.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: List of Options Classes
 ---
 

--- a/src/docs/host/configuration_guide/local_development_configuration.md
+++ b/src/docs/host/configuration_guide/local_development_configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Local development configuration
 ---
 

--- a/src/docs/host/configuration_guide/serialization.md
+++ b/src/docs/host/configuration_guide/serialization.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Serialization and Writing Custom Serializers
 uid: serialization
 ---

--- a/src/docs/host/configuration_guide/server_configuration.md
+++ b/src/docs/host/configuration_guide/server_configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Server Configuration
 ---
 

--- a/src/docs/host/configuration_guide/shutting_down_orleans.md
+++ b/src/docs/host/configuration_guide/shutting_down_orleans.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Shutting down Orleans
 ---
 

--- a/src/docs/host/configuration_guide/startup_tasks.md
+++ b/src/docs/host/configuration_guide/startup_tasks.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Startup Tasks
 ---
 # Startup Tasks

--- a/src/docs/host/configuration_guide/typical_configurations.md
+++ b/src/docs/host/configuration_guide/typical_configurations.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Typical Configurations
 ---
 

--- a/src/docs/host/grain_directory.md
+++ b/src/docs/host/grain_directory.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Grain Directory
 ---
 # Grain Directory

--- a/src/docs/host/heterogeneous_silos.md
+++ b/src/docs/host/heterogeneous_silos.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Heterogeneous silos
 ---
 

--- a/src/docs/host/monitoring/client_error_code_monitoring.md
+++ b/src/docs/host/monitoring/client_error_code_monitoring.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Client Error Code Monitoring
 ---
 

--- a/src/docs/host/monitoring/index.md
+++ b/src/docs/host/monitoring/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Runtime Monitoring
 ---
 

--- a/src/docs/host/monitoring/silo_error_code_monitoring.md
+++ b/src/docs/host/monitoring/silo_error_code_monitoring.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Silo Error Code Monitoring
 ---
 

--- a/src/docs/host/powershell_client.md
+++ b/src/docs/host/powershell_client.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: PowerShell Client Module
 ---
 

--- a/src/docs/host/silo_lifecycle.md
+++ b/src/docs/host/silo_lifecycle.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Silo Lifecycle
 ---
 

--- a/src/docs/implementation/cluster_management.md
+++ b/src/docs/implementation/cluster_management.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Cluster Management in Orleans
 ---
 

--- a/src/docs/implementation/index.md
+++ b/src/docs/implementation/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Implementation Details
 ---
 # Implementation Details Overview

--- a/src/docs/implementation/load_balancing.md
+++ b/src/docs/implementation/load_balancing.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Load Balancing
 ---
 

--- a/src/docs/implementation/messaging_delivery_guarantees.md
+++ b/src/docs/implementation/messaging_delivery_guarantees.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Messaging Delivery Guarantees
 ---
 

--- a/src/docs/implementation/orleans_lifecycle.md
+++ b/src/docs/implementation/orleans_lifecycle.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Lifecycle
 ---
 

--- a/src/docs/implementation/scheduler.md
+++ b/src/docs/implementation/scheduler.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Scheduling
 ---
 

--- a/src/docs/implementation/streams_implementation/azure_queue_streams.md
+++ b/src/docs/implementation/streams_implementation/azure_queue_streams.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Azure Queue Streams Implementation Details
 ---
 

--- a/src/docs/implementation/streams_implementation/index.md
+++ b/src/docs/implementation/streams_implementation/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Streams Implementation Details
 ---
 

--- a/src/docs/implementation/testing.md
+++ b/src/docs/implementation/testing.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Unit Testing
 ---
 

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Introduction
 ---
 

--- a/src/docs/migration/codegen.md
+++ b/src/docs/migration/codegen.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Code Generation in Orleans 2.0
 ---
 

--- a/src/docs/migration/index.md
+++ b/src/docs/migration/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Migration
 ---
 

--- a/src/docs/migration/migration-1.5.md
+++ b/src/docs/migration/migration-1.5.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Migration from Orleans 1.5 to 2.0
 ---
 

--- a/src/docs/migration/migration-azure-2.0.md
+++ b/src/docs/migration/migration-azure-2.0.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Migration from Orleans 1.5 to 2.0 when using Azure
 ---
 

--- a/src/docs/resources/contributing.md
+++ b/src/docs/resources/contributing.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Contributing to Orleans
 ---
 

--- a/src/docs/resources/documentation_guidelines.md
+++ b/src/docs/resources/documentation_guidelines.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Documentation Guidelines
 ---
 

--- a/src/docs/resources/frequently_asked_questions.md
+++ b/src/docs/resources/frequently_asked_questions.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Frequently Asked Questions
 ---
 [//]: # (TODO: after files are rearranged and checked for accuracy, put links back)

--- a/src/docs/resources/index.md
+++ b/src/docs/resources/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Resources
 ---
 # Resources

--- a/src/docs/resources/links.md
+++ b/src/docs/resources/links.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Links
 ---
 

--- a/src/docs/resources/nuget_packages.md
+++ b/src/docs/resources/nuget_packages.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans NuGet Packages
 ---
 

--- a/src/docs/resources/orleans_architecture_principles_and_approach_I.md
+++ b/src/docs/resources/orleans_architecture_principles_and_approach_I.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Architecture - Principles and Approach I
 ---
 

--- a/src/docs/resources/orleans_thinking_big_and_small.md
+++ b/src/docs/resources/orleans_thinking_big_and_small.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans - Thinking Big and Small
 ---
 

--- a/src/docs/resources/presentations/index.md
+++ b/src/docs/resources/presentations/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Presentations
 ---
 

--- a/src/docs/resources/student_projects.md
+++ b/src/docs/resources/student_projects.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Student Projects
 ---
 

--- a/src/docs/streaming/index.md
+++ b/src/docs/streaming/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Streams
 ---
 

--- a/src/docs/streaming/stream_providers.md
+++ b/src/docs/streaming/stream_providers.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Stream Providers
 ---
 

--- a/src/docs/streaming/streams_programming_APIs.md
+++ b/src/docs/streaming/streams_programming_APIs.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Streams Programming APIs
 ---
 

--- a/src/docs/streaming/streams_quick_start.md
+++ b/src/docs/streaming/streams_quick_start.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Orleans Streams Quick Start
 ---
 

--- a/src/docs/streaming/streams_why.md
+++ b/src/docs/streaming/streams_why.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Why Orleans Streams?
 ---
 

--- a/src/docs/tutorials_and_samples/Adventure.md
+++ b/src/docs/tutorials_and_samples/Adventure.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Adventure
 ---
 

--- a/src/docs/tutorials_and_samples/Hello-World.md
+++ b/src/docs/tutorials_and_samples/Hello-World.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Hello World
 ---
 

--- a/src/docs/tutorials_and_samples/custom_grain_storage.md
+++ b/src/docs/tutorials_and_samples/custom_grain_storage.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Custom Grain Storage
 ---
 

--- a/src/docs/tutorials_and_samples/index.md
+++ b/src/docs/tutorials_and_samples/index.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Samples
 ---
 

--- a/src/docs/tutorials_and_samples/overview_helloworld.md
+++ b/src/docs/tutorials_and_samples/overview_helloworld.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Tutorial 1 Hello World
 ---
 

--- a/src/docs/tutorials_and_samples/testing.md
+++ b/src/docs/tutorials_and_samples/testing.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Unit Testing
 ---
 

--- a/src/docs/tutorials_and_samples/tutorial_1.md
+++ b/src/docs/tutorials_and_samples/tutorial_1.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Tutorial One
 ---
 

--- a/src/docs/whats_new_in_orleans.md
+++ b/src/docs/whats_new_in_orleans.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: What's new in Orleans
 ---
 


### PR DESCRIPTION
 * Adds a new **docfx.json** at the *src/docs* level. This is where OPS is expecting to find docfx.json.
* Removes the `layout: page` metadata from every .md file
* Adds a **global** metadata key for `layout: page` in the **docfx.json** file located at the *src* level. 
    * This is presumably the docfx.json file being used for the github.io site. 

Merging this PR should -- and I want to emphasize *should* -- result in these same docs being hosted at both the github.io site (exactly as they are today) AND Microsoft Docs (staging site, not live site) at the following URL: https://review.docs.microsoft.com/en-us/dotnet/orleans/?branch=master

Please note that all these metadata warnings will need to be resolved before publishing to the live site.

[preview link](https://review.docs.microsoft.com/en-us/dotnet/orleans/?branch=pr-en-us-34)