### PR TITLE
Updating testing.md to use TestClusterBuilder

### DIFF
--- a/src/docs/implementation/testing.md
+++ b/src/docs/implementation/testing.md
@@ -53,7 +53,6 @@ public class ClusterFixture : IDisposable
     public ClusterFixture()
     {
         var builder = new TestClusterBuilder();
-        builder.Options.ServiceId = Guid.NewGuid().ToString();
         var cluster = builder.Build();
         this.Cluster.Deploy();
     }

--- a/src/docs/implementation/testing.md
+++ b/src/docs/implementation/testing.md
@@ -27,7 +27,6 @@ namespace Tests
         public async Task SaysHelloCorrectly()
         {
             var builder = new TestClusterBuilder();
-            builder.Options.ServiceId = Guid.NewGuid().ToString();
             var cluster = builder.Build();
             cluster.Deploy();
 

--- a/src/docs/implementation/testing.md
+++ b/src/docs/implementation/testing.md
@@ -26,7 +26,9 @@ namespace Tests
         [Fact]
         public async Task SaysHelloCorrectly()
         {
-            var cluster = new TestCluster();
+            var builder = new TestClusterBuilder();
+            builder.Options.ServiceId = Guid.NewGuid().ToString();
+            var cluster = builder.Build();
             cluster.Deploy();
 
             var hello = cluster.GrainFactory.GetGrain<IHelloGrain>(Guid.NewGuid());
@@ -50,7 +52,9 @@ public class ClusterFixture : IDisposable
 {
     public ClusterFixture()
     {
-        this.Cluster = new TestCluster();
+        var builder = new TestClusterBuilder();
+        builder.Options.ServiceId = Guid.NewGuid().ToString();
+        var cluster = builder.Build();
         this.Cluster.Deploy();
     }
 


### PR DESCRIPTION
Similar to #8.  Sample wasn't compiling because TestCluster doesn't have a parameterless constructor. Changing to use the TestClusterBuilder so the Unit Test sample builds and runs.