### PR TITLE
Replaced obsolete ISiloBuilderConfigurator with ISiloConfigurator

### DIFF
--- a/src/docs/implementation/testing.md
+++ b/src/docs/implementation/testing.md
@@ -131,9 +131,9 @@ public class ClusterFixture : IDisposable
     public TestCluster Cluster { get; private set; }
 }
 
-public class TestSiloConfigurations : ISiloBuilderConfigurator {
-    public void Configure(ISiloHostBuilder hostBuilder) {
-        hostBuilder.ConfigureServices(services => {
+public class TestSiloConfigurations : ISiloConfigurator {
+    public void Configure(ISiloBuilder siloBuilder) {
+        siloBuilder.ConfigureServices(services => {
             services.AddSingleton<T, Impl>(...);
         });
     }

--- a/src/docs/tutorials_and_samples/testing.md
+++ b/src/docs/tutorials_and_samples/testing.md
@@ -27,7 +27,6 @@ namespace Tests
         public async Task SaysHelloCorrectly()
         {
             var builder = new TestClusterBuilder();
-            builder.Options.ServiceId = Guid.NewGuid().ToString();
             var cluster = builder.Build();
             cluster.Deploy();
 
@@ -52,7 +51,8 @@ public class ClusterFixture : IDisposable
 {
     public ClusterFixture()
     {
-        this.Cluster = new TestCluster();
+        var builder = new TestClusterBuilder();
+        var cluster = builder.Build();
         this.Cluster.Deploy();
     }
 
@@ -131,9 +131,9 @@ public class ClusterFixture : IDisposable
     public TestCluster Cluster { get; private set; }
 }
 
-public class TestSiloConfigurations : ISiloBuilderConfigurator {
-    public void Configure(ISiloHostBuilder hostBuilder) {
-        hostBuilder.ConfigureServices(services => {
+public class TestSiloConfigurations : ISiloConfigurator {
+    public void Configure(ISiloBuilder siloBuilder) {
+        siloBuilder.ConfigureServices(services => {
             services.AddSingleton<T, Impl>(...);
         });
     }


### PR DESCRIPTION
Please note: there are now 2 identical pages regarding unit testing ([one](https://github.com/dotnet/orleans-docs/blob/main/src/docs/implementation/testing.md), [two](https://github.com/dotnet/orleans-docs/blob/main/src/docs/tutorials_and_samples/testing.md)). It makes it easy to get differences (I've fixed one already in this PR). Either we drop one of them entirely or we alter the menu to make both menu items to the same file.

I do have another improvement regarding the docs I'll wait until it is clear we really need to seperate doc files for the same content or not.