### PR TITLE
Update "...samples/2.0/..." link

### DIFF
--- a/src/docs/tutorials_and_samples/overview_helloworld.md
+++ b/src/docs/tutorials_and_samples/overview_helloworld.md
@@ -4,7 +4,7 @@ title: Tutorial 1 Hello World
 
 # Overview: Hello World
 
-This overview ties into the Hello World sample application available [here](https://github.com/dotnet/orleans/tree/master/Samples/2.0/HelloWorld).
+This overview ties into the Hello World sample application available [here](https://github.com/dotnet/orleans/tree/main/samples/HelloWorld).
 
 The main concepts of Orleans involve a silo, a client, and one or more grains.
 Creating an Orleans app involves configuring the silo, configuring the client, and writing the grains.


### PR DESCRIPTION
Updates outdated link of ".../master/Samples/2.0/..." to ".../main/samples/..."

from page https://dotnet.github.io/orleans/docs/tutorials_and_samples/overview_helloworld.html

![image](https://user-images.githubusercontent.com/8814983/142071411-e111696a-85e5-4e75-886e-1c28484b23f5.png)
