### PR TITLE
The GPS Tracker heading not rendering

### DIFF
--- a/src/docs/tutorials_and_samples/index.md
+++ b/src/docs/tutorials_and_samples/index.md
@@ -49,6 +49,7 @@ Publishers send out short *"Chirp"* messages (not to be confused with *"Tweets"*
 * Grains which implement multiple grain interfaces
 * Reentrant grains, which allow for multiple grain calls to be executed concurrently, in a single-threaded, interleaving fashion
 * Using a *grain observer* (`IGrainObserver`) to receive push notifications from grains
+
 ## [GPS Tracker](https://github.com/dotnet/orleans/raw/main/samples/GPSTracker/#readme)
 
 <p align="center">


### PR DESCRIPTION
On the documentation site the GPS Rendering heading was rendering as part of the previous bullet point.  Adding a space after the bullet point should fix the issue.