### PR TITLE
Show correct information about AdoNet scripts

### DIFF
--- a/src/docs/host/configuration_guide/configuring_ADO.NET_providers.md
+++ b/src/docs/host/configuration_guide/configuring_ADO.NET_providers.md
@@ -51,8 +51,8 @@ siloHostBuilder.UseAdoNetClustering(options =>
 
 Where the `ConnectionString` is set to a valid AdoNet Server connection string. 
 
-In order to use ADO.NET providers for persistence, reminders or clustering, there are scripts for creating database artifacts, to which all servers that will be hosting Orleans silos need to have access.
+In order to use ADO.NET providers for persistence, reminders or clustering, there are scripts for creating database artifacts, to which all servers that will be hosting Orleans silos need to have access. The scripts for most popular providers can be found in [ADO.NET Configuration](~/docs/host/configuration_guide/adonet_configuration.md).
 Lack of access to the target database is a typical mistake we see developers making.
 
-The scripts will be copied to project directory \OrleansAdoNetContent where each supported ADO.NET extensions has its own directory, after you install or do a nuget restore on the AdoNet extension nugets. We split AdoNet nugets into per feature nugets:
+You also need to install AdoNet nuget for feature you configure. We split AdoNet nugets into per feature nugets:
 `Microsoft.Orleans.Clustering.AdoNet` for clustering, `Microsoft.Orleans.Persistence.AdoNet` for persistence and `Microsoft.Orleans.Reminders.AdoNet` for reminders.


### PR DESCRIPTION
It looks like this part of documentation was not changed after scripts were removed from nuget packages. I spent quite a while today looking everywhere for OrleansAdoNetContent folder, while the scripts were listed on next docs page.